### PR TITLE
Prevent default space press on image resize

### DIFF
--- a/scripts/question.js
+++ b/scripts/question.js
@@ -911,6 +911,7 @@ H5P.Question = (function ($, EventDispatcher, JoubelUI) {
             }
           }).on('keypress', function (event) {
             if (event.which === 32) {
+              event.preventDefault(); // Prevent default behaviour; page scroll down
               scaleImage.apply(this); // Space bar pressed
             }
           });


### PR DESCRIPTION
The spacebar default action within web document context, is to scroll the page. Therefore it is required to prevent this when triggering another action with the spacebar, within the context of the question image's resize (scale) action.

You also might need to consider to listen for key modifiers, like shift, ctrl, alt and meta, since these may trigger other actions as well. The Shift modifier for example, is used for reverse actions. For spacebar press with shift that would mean to scroll up instead of scrolling down.