### PR TITLE
Update question.js

### DIFF
--- a/scripts/question.js
+++ b/scripts/question.js
@@ -1352,6 +1352,12 @@ H5P.Question = (function ($, EventDispatcher, JoubelUI) {
         html: text,
         on: {
           click: function (event) {
+            // Make sure that the button becomes the active element after click
+            // See https://bugs.webkit.org/show_bug.cgi?id=22261 for more details about how Safari behaves
+            if (document.activeElement !== this) {
+              $(this).focus();
+            }
+
             handleButtonClick();
             if (isAnchorTag) {
               event.preventDefault();


### PR DESCRIPTION
Fixed an issue with not scrolling back to the question element in Safari and at least one version of Chrome (in Windows). The issue is with button element not receiving a focus and becoming an active element of the document.

[This](https://gituja.eenet.ee/sisuloome/sisuloome/-/issues/1) issue has a bit more information on the matter.