### PR TITLE
HFP-3654 Fix trailing "dot" for screen readers

### DIFF
--- a/scripts/question.js
+++ b/scripts/question.js
@@ -1161,7 +1161,7 @@ H5P.Question = (function ($, EventDispatcher, JoubelUI) {
 
       // Feedback for readspeakers
       if (!behaviour.disableReadSpeaker && scoreBarLabel) {
-        self.read(scoreBarLabel.replace(':num', score).replace(':total', maxScore) + '. ' + (content ? content : ''));
+        self.read(scoreBarLabel.replace(':num', score).replace(':total', maxScore) + (content ? '. ' + content : ''));
       }
 
       showFeedback = true;


### PR DESCRIPTION
When merged in, will prevent the score feedback to create a string that may cause the `read` function to read something like `You got x out of y points. . Something else` (with an extra "dot" in between).

## background
Currently, when building the string that's read as feedback from the score bar and the `content` string is empty, the resulting string will be something like:
`You got x out of y points. ` with a trailing space at the end. When the read function receives some other string before the feedback is read, it will concatenate the feedback string with the other string, but also put a `. ` in between that will cause a "dot" to be read.