### PR TITLE
HFP-3824 Add fix for dialog on embedded fullscreen

### DIFF
--- a/scripts/question.js
+++ b/scripts/question.js
@@ -1464,7 +1464,14 @@ H5P.Question = (function ($, EventDispatcher, JoubelUI) {
 
       // Determine parent element
       if (options.$parentElement) {
-        confirmationDialog.appendTo(options.$parentElement.get(0));
+        const parentElement = options.$parentElement.get(0);
+        let dialogParent;
+        // If using h5p-content, dialog will not appear on embedded fullscreen
+        if (parentElement.classList.contains('h5p-content')) {
+          dialogParent = parentElement.querySelector('.h5p-container');
+        }
+
+        confirmationDialog.appendTo(dialogParent ?? parentElement);
       }
       else {
 


### PR DESCRIPTION
When merged in and a content types requests to attach the H5P.ConfirmationDialog to the `h5p-content` element, try to use the `h5p-container` element instead. Otherwise, the confirmation dialog will not show when the content is embedded and in full screen mode.