### PR TITLE
VA-854 remove duplicate css

### DIFF
--- a/styles/question.css
+++ b/styles/question.css
@@ -486,54 +486,6 @@
   container-type: inline-size;
 }
 
-.h5p-theme .h5p-theme-primary-cta {
-  padding: var(--h5p-theme-spacing-xs) calc(var(--h5p-theme-spacing-l));
-  background-color: var(--h5p-theme-main-cta-base);
-  color: var(--h5p-theme-contrast-cta);
-  border-radius: var(--h5p-theme-border-radius-medium);
-  cursor: pointer;
-  font-size: var(--h5p-theme-font-size-m);
-  border: solid 3px var(--h5p-theme-main-cta-base);
-  transition: all 0.1s linear 0s;
-  transition-property: text-indent, padding;
-}
-
-.h5p-theme .h5p-theme-primary-cta:hover {
-  padding: var(--h5p-theme-spacing-xs) calc(var(--h5p-theme-spacing-l) - 0.75em);
-  background-color: var(--h5p-theme-main-cta-light);
-  border-color: var(--h5p-theme-main-cta-light);
-}
-
-.h5p-theme .h5p-theme-primary-cta:active {
-  background-color: var(--h5p-theme-main-cta-dark);
-   border-color: var(--h5p-theme-main-cta-dark);
-}
-
-.h5p-theme .h5p-theme-secondary-cta {
-  background-color: var(--h5p-theme-ui-base);
-  color: var(--h5p-theme-main-cta-base);
-  border-radius: var(--h5p-theme-border-radius-medium);
-  border: solid 3px var(--h5p-theme-main-cta-base) !important;
-  padding: var(--h5p-theme-spacing-xs) var(--h5p-theme-spacing-s);
-  font-size: var(--h5p-theme-font-size-m);
-
-  transition: all 0.1s linear 0s;
-  transition-property: text-indent, padding;
-}
-
-.h5p-theme .h5p-theme-secondary-cta:hover {
-  background-color: var(--h5p-theme-main-cta-base);
-  border-color: var(--h5p-theme-main-cta-base);
-  color: var(--h5p-theme-contrast-cta);
-  cursor: pointer;
-}
-
-.h5p-theme .h5p-theme-secondary-cta:active {
-  background-color: var(--h5p-theme-main-cta-dark);
-  border-color: var(--h5p-theme-main-cta-dark);
-  color: var(--h5p-theme-contrast-cta);
-}
-
 .h5p-theme .h5p-question-feedback.h5p-question-visible {
   margin: 0em;
 }


### PR DESCRIPTION
Note: After removing this, the secondary cta (`h5p-theme-secondary.cta`) will no longer have the property: `transition-property: text-indent, padding`. It is not present in H5P Components and considering that the background is supposed to change, it does not seem to make sense to **not** have a transition on background.