### PR TITLE
VA-946 Fix updating feedback text

### DIFF
--- a/scripts/question.js
+++ b/scripts/question.js
@@ -382,8 +382,12 @@ H5P.Question = (function ($, EventDispatcher, JoubelUI) {
      * @param {H5P.jQuery} $element
      */
     var setElementHeight = function ($element) {
-      if (!$element.is(':visible')) {
-        // No animation
+      // Setting a fixed max-height on the feedback element when it has a theme can cause overflow
+      const isFeedback = $element[0].classList.contains('h5p-question-feedback');
+      const isH5PTheme = $element[0].closest('.h5p-question.h5p-theme') !== null;
+
+      if (!$element.is(':visible') || (isFeedback && isH5PTheme)) {
+        // No animation or feedback with H5P theme
         $element.css('max-height', 'none');
         return;
       }

--- a/scripts/question.js
+++ b/scripts/question.js
@@ -1315,11 +1315,11 @@ H5P.Question = (function ($, EventDispatcher, JoubelUI) {
       if (sections.feedback && sections.feedback.$element) {
 
         if (extendContent) {
-          content = $('.h5p-question-feedback-content', sections.feedback.$element).html() + ' ' + content;
+          content = $('.h5p-question-feedback-content-text', sections.feedback.$element).html() + ' ' + content;
         }
 
         // Update feedback content html
-        $('.h5p-question-feedback-content', sections.feedback.$element).html(content).addClass('has-content');
+        $('.h5p-question-feedback-content-text', sections.feedback.$element).html(content).addClass('has-content');
 
         // Make sure the height is correct
         setElementHeight(sections.feedback.$element);


### PR DESCRIPTION
When merged, will not overwrite the `h5p-question-feedback-content-text` element with plain text but append/replace it's inner HTML.